### PR TITLE
Update joint_log_like.m

### DIFF
--- a/Gibbs LDA/joint_log_like.m
+++ b/Gibbs LDA/joint_log_like.m
@@ -48,7 +48,7 @@ ll = ll + nDocs*(gammaln(nTopics*alpha) - nTopics*gammaln(alpha));
 % integrating out topic distribution)
 for d = 1:nDocs
  ll = ll + sum(gammaln(alpha + nDocumentTopic(d,:)));
- ll = ll - gammaln(nTopics*alpha + Nd(d));
+ ll = ll - gammaln(nTopic*alpha + Nd(d));
 end
 
 % log of normalization constant for prior of word distribution


### PR DESCRIPTION
Fixed bug in log-likelihood computation. 

@AmazaspShumik 

You should use vector (that represents number of words assigned to each topic) not number of topics !
Please, improve notation !!!  In your nTopics - number of topics, while nTopic - number of words assigned to each topic (I think every reasonable human being would agree that this is quite misleading)
